### PR TITLE
Handle unset environment in CMake condition gracefully

### DIFF
--- a/prom/CMakeLists.txt
+++ b/prom/CMakeLists.txt
@@ -121,7 +121,7 @@ target_sources(
 
 target_link_libraries(prom PUBLIC Threads::Threads)
 
-if ($ENV{TEST} EQUAL "1")
+if ($ENV{TEST})
     include(test/CMakeLists.txt)
 endif()
 


### PR DESCRIPTION
This fixes a CMake Error when if the environment variable is not set.

```
-- Found Threads: TRUE  
CMake Error at CMakeLists.txt:124 (if):
  if given arguments:

    "EQUAL" "1"

  Unknown arguments specified


-- Configuring incomplete, errors occurred!

```