### PR TITLE
Make path to includes relative (honor CMAKE_INSTALL_PREFIX)

### DIFF
--- a/prom/CMakeLists.txt
+++ b/prom/CMakeLists.txt
@@ -136,5 +136,6 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A prometheus client library")
 set(CPACK_PACKAGE_HOMEPAGE_URL https://github.internal.digitalocean.com/timeseries/prometheus-client-c)
 
 include(CPack)
+include(GNUInstallDirs)
 install(TARGETS prom ARCHIVE)
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/prom/CMakeLists.txt
+++ b/prom/CMakeLists.txt
@@ -137,4 +137,4 @@ set(CPACK_PACKAGE_HOMEPAGE_URL https://github.internal.digitalocean.com/timeseri
 
 include(CPack)
 install(TARGETS prom ARCHIVE)
-install(DIRECTORY include/ DESTINATION usr/include)
+install(DIRECTORY include/ DESTINATION include)

--- a/prom/CMakeLists.txt
+++ b/prom/CMakeLists.txt
@@ -137,4 +137,4 @@ set(CPACK_PACKAGE_HOMEPAGE_URL https://github.internal.digitalocean.com/timeseri
 
 include(CPack)
 install(TARGETS prom ARCHIVE)
-install(DIRECTORY include/ DESTINATION /usr/include/)
+install(DIRECTORY include/ DESTINATION usr/include)

--- a/promhttp/CMakeLists.txt
+++ b/promhttp/CMakeLists.txt
@@ -74,5 +74,6 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "libprom-dev (= ${Version})")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libmicrohttpd-dev")
 
 include(CPack)
+include(GNUInstallDirs)
 install(TARGETS promhttp ARCHIVE)
-install(DIRECTORY include/ DESTINATION /usr/include/)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Install paths must be relative, otherwise CMAKE_INSTALL_PREFIX is ignored and

```
make install
```

tries to write to /usr/include regardless CMAKE_INSTALL_PREFIX. 

```
 TEST="0" cmake  ./  -DCMAKE_INSTALL_PREFIX=/tmp/hello && make && make install
-- Configuring done
-- Generating done
-- Build files have been written to: /home/carlos/deleteme/prometheus-client-c-0.1.1/prom
[100%] Built target prom
[100%] Built target prom
Install the project...
-- Install configuration: ""
-- Up-to-date: /tmp/hello/lib/libprom.so
-- Up-to-date: /usr/include/
CMake Error at cmake_install.cmake:68 (file):
  file INSTALL cannot set permissions on "/usr/include/": Operation not
  permitted.

make: *** [Makefile:97: install] Error 1
```

Also removed trailing slash (to prevent // in paths).