### PR TITLE
Support GCC 10

### DIFF
--- a/prom/include/prom_collector_registry.h
+++ b/prom/include/prom_collector_registry.h
@@ -34,7 +34,7 @@ typedef struct prom_collector_registry prom_collector_registry_t;
  * @brief Initialize the default registry by calling prom_collector_registry_init within your program. You MUST NOT
  * modify this value.
  */
-prom_collector_registry_t *PROM_COLLECTOR_REGISTRY_DEFAULT;
+extern prom_collector_registry_t *PROM_COLLECTOR_REGISTRY_DEFAULT;
 
 /**
  * @brief Initializes the default collector registry and enables metric collection on the executing process

--- a/prom/include/prom_histogram_buckets.h
+++ b/prom/include/prom_histogram_buckets.h
@@ -41,7 +41,7 @@ prom_histogram_buckets_t* prom_histogram_buckets_new(size_t count, double bucket
 /**
  * @brief the default histogram buckets: .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10
  */
-prom_histogram_buckets_t *prom_histogram_default_buckets;
+extern prom_histogram_buckets_t *prom_histogram_default_buckets;
 
 /**
  *@brief Construct a linearly sized prom_histogram_buckets_t*

--- a/prom/src/prom_collector_registry.c
+++ b/prom/src/prom_collector_registry.c
@@ -37,6 +37,7 @@
 #include "prom_process_limits_i.h"
 #include "prom_string_builder_i.h"
 
+prom_collector_registry_t *PROM_COLLECTOR_REGISTRY_DEFAULT;
 
 prom_collector_registry_t* prom_collector_registry_new(const char *name)
 {

--- a/prom/src/prom_histogram_buckets.c
+++ b/prom/src/prom_histogram_buckets.c
@@ -25,6 +25,8 @@
 #include "prom_assert.h"
 #include "prom_log.h"
 
+prom_histogram_buckets_t *prom_histogram_default_buckets;
+
 prom_histogram_buckets_t* prom_histogram_buckets_new(size_t count, double bucket, ...) {
   prom_histogram_buckets_t *self = (prom_histogram_buckets_t*) prom_malloc(sizeof(prom_histogram_buckets_t));
   double *upper_bounds = (double*) prom_malloc(sizeof(double)*count);

--- a/prom/src/prom_metric_t.h
+++ b/prom/src/prom_metric_t.h
@@ -42,7 +42,7 @@ typedef enum prom_metric_type {
 /**
  * @brief API PRIVATE Maps metric type constants to human readable string values
  */
-char *prom_metric_type_map[4];
+extern char *prom_metric_type_map[4];
 
 /**
  * @brief API PRIVATE An opaque struct to users containing metric metadata; one or more metric samples; and a metric formatter

--- a/prom/src/prom_process_fds.c
+++ b/prom/src/prom_process_fds.c
@@ -30,6 +30,8 @@
 #include "prom_log.h"
 #include "prom_process_fds_t.h"
 
+prom_gauge_t *prom_process_open_fds;
+
 int prom_process_fds_count(const char *path) {
   int count = 0;
   int r = 0;

--- a/prom/src/prom_process_fds_t.h
+++ b/prom/src/prom_process_fds_t.h
@@ -19,6 +19,6 @@
 #ifndef PROM_PROESS_FDS_T_H
 #define PROM_PROESS_FDS_T_H
 
-prom_gauge_t *prom_process_open_fds;
+extern prom_gauge_t *prom_process_open_fds;
 
 #endif // PROM_PROESS_FDS_T_H

--- a/prom/src/prom_process_limits.c
+++ b/prom/src/prom_process_limits.c
@@ -49,6 +49,10 @@ typedef enum prom_process_limit_rdp_limit_type {
   PROM_PROCESS_LIMITS_RDP_HARD
 } prom_process_limit_rdp_limit_type_t;
 
+prom_gauge_t *prom_process_virtual_memory_max_bytes;
+prom_gauge_t *prom_process_resident_memory_bytes;
+prom_gauge_t *prom_process_max_fds;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // prom_process_limits_row_t
 

--- a/prom/src/prom_process_limits_t.h
+++ b/prom/src/prom_process_limits_t.h
@@ -21,10 +21,10 @@
 #include "prom_procfs_t.h"
 
 
-prom_gauge_t *prom_process_open_fds;
-prom_gauge_t *prom_process_max_fds;
-prom_gauge_t *prom_process_virtual_memory_max_bytes;
-prom_gauge_t *prom_process_resident_memory_bytes;
+extern prom_gauge_t *prom_process_open_fds;
+extern prom_gauge_t *prom_process_max_fds;
+extern prom_gauge_t *prom_process_virtual_memory_max_bytes;
+extern prom_gauge_t *prom_process_resident_memory_bytes;
 
 
 typedef struct prom_process_limits_row {

--- a/prom/src/prom_process_stat.c
+++ b/prom/src/prom_process_stat.c
@@ -28,6 +28,10 @@
 #include "prom_process_stat_t.h"
 #include "prom_procfs_i.h"
 
+prom_gauge_t *prom_process_cpu_seconds_total;
+prom_gauge_t *prom_process_virtual_memory_bytes;
+prom_gauge_t *prom_process_start_time_seconds;
+
 prom_process_stat_file_t* prom_process_stat_file_new(const char *path) {
   if (path) {
     return prom_procfs_buf_new(path);

--- a/prom/src/prom_process_stat_t.h
+++ b/prom/src/prom_process_stat_t.h
@@ -22,9 +22,9 @@
 
 #include "prom_procfs_t.h"
 
-prom_gauge_t *prom_process_cpu_seconds_total;
-prom_gauge_t *prom_process_virtual_memory_bytes;
-prom_gauge_t *prom_process_start_time_seconds;
+extern prom_gauge_t *prom_process_cpu_seconds_total;
+extern prom_gauge_t *prom_process_virtual_memory_bytes;
+extern prom_gauge_t *prom_process_start_time_seconds;
 
 /**
  * @brief Refer to man proc and search for /proc/[pid]/stat

--- a/promhttp/src/promhttp.c
+++ b/promhttp/src/promhttp.c
@@ -31,7 +31,7 @@ void promhttp_set_active_collector_registry(prom_collector_registry_t *active_re
   }
 }
 
-int promhttp_handler(void *cls,
+enum MHD_Result promhttp_handler(void *cls,
                      struct MHD_Connection *connection,
                      const char *url,
                      const char *method,
@@ -43,27 +43,27 @@ int promhttp_handler(void *cls,
   if (strcmp(method, "GET") != 0) {
     char *buf = "Invalid HTTP Method\n";
     struct MHD_Response *response = MHD_create_response_from_buffer(strlen(buf), (void*) buf, MHD_RESPMEM_PERSISTENT);
-    int ret = MHD_queue_response(connection, MHD_HTTP_BAD_REQUEST, response);
+    enum MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_BAD_REQUEST, response);
     MHD_destroy_response(response);
     return ret;
   }
   if (strcmp(url, "/") == 0) {
     char *buf = "OK\n";
     struct MHD_Response *response = MHD_create_response_from_buffer(strlen(buf), (void*) buf, MHD_RESPMEM_PERSISTENT);
-    int ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
+    enum MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
     MHD_destroy_response(response);
     return ret;
   }
   if (strcmp(url, "/metrics") == 0) {
     const char *buf = prom_collector_registry_bridge(PROM_ACTIVE_REGISTRY);
     struct MHD_Response *response = MHD_create_response_from_buffer(strlen(buf), (void*) buf, MHD_RESPMEM_MUST_FREE);
-    int ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
+    enum MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
     MHD_destroy_response(response);
     return ret;
   }
    char *buf = "Bad Request\n";
    struct MHD_Response *response = MHD_create_response_from_buffer(strlen(buf), (void*) buf, MHD_RESPMEM_PERSISTENT);
-   int ret = MHD_queue_response(connection, MHD_HTTP_BAD_REQUEST, response);
+   enum MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_BAD_REQUEST, response);
    MHD_destroy_response(response);
    return ret;
 }


### PR DESCRIPTION
I was getting errors like these when trying compile with GCC 10, which ships with Fedora 32:
```
/usr/bin/ld: CMakeFiles/prom.dir/src/prom_collector_registry.c.o:(.bss+0x0): multiple definition of `prom_histogram_default_buckets'; CMakeFiles/prom.dir/src/prom_collector.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/prom.dir/src/prom_collector_registry.c.o:(.bss+0x20): multiple definition of `prom_metric_type_map'; CMakeFiles/prom.dir/src/prom_collector.c.o:(.bss+0x20): first defined here
/usr/bin/ld: CMakeFiles/prom.dir/src/prom_collector_registry.c.o:(.bss+0x40): multiple definition of `prom_process_open_fds'; CMakeFiles/prom.dir/src/prom_collector.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/prom.dir/src/prom_collector_registry.c.o:(.bss+0x48): multiple definition of `prom_process_max_fds'; CMakeFiles/prom.dir/src/prom_collector.c.o:(.bss+0x48): first defined here
/usr/bin/ld: CMakeFiles/prom.dir/src/prom_collector_registry.c.o:(.bss+0x50): multiple definition of `prom_process_virtual_memory_max_bytes'; CMakeFiles/prom.dir/src/prom_collector.c.o:(.bss+0x50): first defined here
/usr/bin/ld: CMakeFiles/prom.dir/src/prom_collector_registry.c.o:(.bss+0x58): multiple definition of `prom_process_resident_memory_bytes'; CMakeFiles/prom.dir/src/prom_collector.c.o:(.bss+0x58): first defined here
```
This PR updates the code according to this document: https://gcc.gnu.org/gcc-10/porting_to.html#common