### PR TITLE
Allow prom_collector_registry_default_init to return success

### DIFF
--- a/prom/src/prom_collector_registry.c
+++ b/prom/src/prom_collector_registry.c
@@ -91,12 +91,9 @@ int prom_collector_registry_enable_custom_process_metrics(prom_collector_registr
 int prom_collector_registry_default_init(void) {
   if (PROM_COLLECTOR_REGISTRY_DEFAULT != NULL) return 0;
 
-  int r = 0;
-
   PROM_COLLECTOR_REGISTRY_DEFAULT = prom_collector_registry_new("default");
   if (PROM_COLLECTOR_REGISTRY_DEFAULT) {
-    r = prom_collector_registry_enable_process_metrics(PROM_COLLECTOR_REGISTRY_DEFAULT);
-    if (r) return r;
+    return prom_collector_registry_enable_process_metrics(PROM_COLLECTOR_REGISTRY_DEFAULT);
   }
   return 1;
 }


### PR DESCRIPTION
When prom_collector_registry_default_init is called for the first time, there's no way it can return zero (success).
The return value of prom_collector_registry_enable_process_metrics should be passed back to the caller.