### PR TITLE
Resolving ISSUE-34

### DIFF
--- a/prom/src/prom_metric_formatter.c
+++ b/prom/src/prom_metric_formatter.c
@@ -171,7 +171,7 @@ int prom_metric_formatter_load_sample(prom_metric_formatter_t *self, prom_metric
   if (r) return r;
 
   char buffer[50];
-  sprintf(buffer, "%f", sample->r_value);
+  sprintf(buffer, "%.17g", sample->r_value);
   r = prom_string_builder_add_str(self->string_builder, buffer);
   if (r) return r;
 

--- a/prom/src/prom_metric_sample_histogram.c
+++ b/prom/src/prom_metric_sample_histogram.c
@@ -501,6 +501,9 @@ static void prom_metric_sample_histogram_free_str_generic(void *gen) {
 
 char *prom_metric_sample_histogram_bucket_to_str(double bucket) {
   char *buf = (char *)prom_malloc(sizeof(char) * 50);
-  sprintf(buf, "%f", bucket);
+  sprintf(buf, "%g", bucket);
+  if (!strchr(buf, '.')) {
+    strcat(buf, ".0");
+  }
   return buf;
 }

--- a/prom/test/prom_collector_registry_test.c
+++ b/prom/test/prom_collector_registry_test.c
@@ -67,16 +67,29 @@ void test_prom_collector_registry_bridge(void) {
 
   const char *result = prom_collector_registry_bridge(PROM_COLLECTOR_REGISTRY_DEFAULT);
 
-  const char *expected =
-      "# HELP test_counter counter under test\n# TYPE test_counter counter\ntest_counter{label=\"foo\"} 1.000000\n\n# "
-      "HELP test_gauge gauge under test\n# TYPE test_gauge gauge\ntest_gauge{label=\"foo\"} 2.000000\n\n# HELP "
-      "test_histogram histogram under test\n# TYPE test_histogram histogram\ntest_histogram{le=\"5.000000\"} "
-      "1.000000\ntest_histogram{le=\"10.000000\"} 2.000000\ntest_histogram{le=\"+Inf\"} 2.000000\ntest_histogram_count "
-      "2.000000\ntest_histogram_sum 10.000000\n\n# HELP process_max_fds Maximum number of open file descriptors.\n# "
-      "TYPE process_max_fds gauge\nprocess_max_fds 1048576.000000\n\n# HELP process_virtual_memory_max_bytes Maximum "
-      "amount of virtual memory available in bytes.\n# TYPE process_virtual_memory_max_bytes "
-      "gauge\nprocess_virtual_memory_max_bytes -1.000000\n\n";
-  TEST_ASSERT_NOT_NULL(strstr(result, expected));
+  const char *expected[] = {
+      "# HELP test_counter counter under test",
+      "# TYPE test_counter counter",
+      "test_counter{label=\"foo\"}",
+      "HELP test_gauge gauge under test",
+      "# TYPE test_gauge gauge",
+      "test_gauge{label=\"foo\"}",
+      "# HELP test_histogram histogram under test",
+      "# TYPE test_histogram histogram\ntest_histogram{le=\"5.0\"}",
+      "test_histogram{le=\"10.0\"}",
+      "test_histogram{le=\"+Inf\"}",
+      "test_histogram_count",
+      "test_histogram_sum",
+      "# HELP process_max_fds Maximum number of open file descriptors.",
+      "# TYPE process_max_fds gauge",
+      "process_max_fds",
+      "# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.",
+      "# TYPE process_virtual_memory_max_bytes"};
+
+  for (int i = 0; i < 17; i++) {
+    TEST_ASSERT_NOT_NULL(strstr(result, expected[i]));
+  }
+
   free((char *)result);
   result = NULL;
 

--- a/prom/test/prom_histogram_test.c
+++ b/prom/test/prom_histogram_test.c
@@ -31,7 +31,7 @@ void test_prom_histogram(void) {
   char *bucket_key = prom_metric_sample_histogram_bucket_to_str(5.0);
   const char *l_value = prom_map_get(h_sample->l_values, bucket_key);
   prom_metric_sample_t *sample = (prom_metric_sample_t *)prom_map_get(h_sample->samples, l_value);
-  TEST_ASSERT_EQUAL_STRING("test_histogram{le=\"5.000000\"}", sample->l_value);
+  TEST_ASSERT_EQUAL_STRING("test_histogram{le=\"5.0\"}", sample->l_value);
   TEST_ASSERT_EQUAL_DOUBLE(1.0, sample->r_value);
   free((char *)bucket_key);
   bucket_key = NULL;
@@ -39,7 +39,7 @@ void test_prom_histogram(void) {
   bucket_key = prom_metric_sample_histogram_bucket_to_str(10.0);
   l_value = prom_map_get(h_sample->l_values, bucket_key);
   sample = (prom_metric_sample_t *)prom_map_get(h_sample->samples, l_value);
-  TEST_ASSERT_EQUAL_STRING("test_histogram{le=\"10.000000\"}", sample->l_value);
+  TEST_ASSERT_EQUAL_STRING("test_histogram{le=\"10.0\"}", sample->l_value);
   TEST_ASSERT_EQUAL_DOUBLE(2.0, sample->r_value);
   free((char *)bucket_key);
   bucket_key = NULL;
@@ -47,7 +47,7 @@ void test_prom_histogram(void) {
   bucket_key = prom_metric_sample_histogram_bucket_to_str(15.0);
   l_value = prom_map_get(h_sample->l_values, bucket_key);
   sample = (prom_metric_sample_t *)prom_map_get(h_sample->samples, l_value);
-  TEST_ASSERT_EQUAL_STRING("test_histogram{le=\"15.000000\"}", sample->l_value);
+  TEST_ASSERT_EQUAL_STRING("test_histogram{le=\"15.0\"}", sample->l_value);
   TEST_ASSERT_EQUAL_DOUBLE(3.0, sample->r_value);
   free((char *)bucket_key);
   bucket_key = NULL;

--- a/promtest/test/promtest_counter.c
+++ b/promtest/test/promtest_counter.c
@@ -175,7 +175,6 @@ static int promtest_parse_counter_output(const char *output, char **value) {
       TEST_FAIL_MESSAGE("failed to get metric sample");
     }
     *value = (char *)json_object_get_string(sample, "value");
-    break;
   }
   if (strlen(*value) == 0) {
     return 1;

--- a/promtest/test/promtest_gauge.c
+++ b/promtest/test/promtest_gauge.c
@@ -175,7 +175,6 @@ static int promtest_parse_gauge_output(const char *output, char **value) {
       TEST_FAIL_MESSAGE("failed to get metric sample");
     }
     *value = (char *)json_object_get_string(sample, "value");
-    break;
   }
   if (strlen(*value) == 0) {
     return 1;


### PR DESCRIPTION
[Reference](https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md#considerations-canonical-numbers)

* Using .17g to format the metric values. 
* Using g to format the le label value for buckets. If no decimal value is present, ".0" is appended to make it clear that it's a float. 