### PR TITLE
#41 - process_cpu_seconds_total include utime + stime

### DIFF
--- a/prom/src/prom_collector.c
+++ b/prom/src/prom_collector.c
@@ -218,7 +218,7 @@ prom_map_t *prom_collector_process_collect(prom_collector_t *self) {
   prom_process_stat_t *stat = prom_process_stat_new(stat_f);
 
   // Set the metrics related to the stat file
-  r = prom_gauge_set(prom_process_cpu_seconds_total, ((stat->cutime + stat->cstime) / 100), NULL);
+  r = prom_gauge_set(prom_process_cpu_seconds_total, ((stat->cutime + stat->cstime + stat->utime + stat->stime) / 100), NULL);
   if (r) {
     prom_process_limits_file_destroy(limits_f);
     prom_map_destroy(limits_map);

--- a/prom/src/prom_collector.c
+++ b/prom/src/prom_collector.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 
 // Public
 #include "prom_alloc.h"
@@ -218,7 +219,7 @@ prom_map_t *prom_collector_process_collect(prom_collector_t *self) {
   prom_process_stat_t *stat = prom_process_stat_new(stat_f);
 
   // Set the metrics related to the stat file
-  r = prom_gauge_set(prom_process_cpu_seconds_total, ((stat->cutime + stat->cstime + stat->utime + stat->stime) / 100), NULL);
+  r = prom_gauge_set(prom_process_cpu_seconds_total, ((stat->utime + stat->stime) / sysconf(_SC_CLK_TCK)), NULL);
   if (r) {
     prom_process_limits_file_destroy(limits_f);
     prom_map_destroy(limits_map);


### PR DESCRIPTION
Calculate `process_cpu_seconds_total` as `utime + stime + cutime + cstime` instead of  `cutime + cstime`.

This  include an amount of time that this process has been scheduled in user and kernel modes (utime + stime) in addition to an amount of time that this process's waited-for children have been scheduled in user and kernel modes modes (cutime + cstime) 