### PR TITLE
#46 - added process_resident_memory_bytes metric

### DIFF
--- a/prom/src/prom_process_limits.c
+++ b/prom/src/prom_process_limits.c
@@ -47,7 +47,6 @@ typedef enum prom_process_limit_rdp_limit_type {
 } prom_process_limit_rdp_limit_type_t;
 
 prom_gauge_t *prom_process_virtual_memory_max_bytes;
-prom_gauge_t *prom_process_resident_memory_bytes;
 prom_gauge_t *prom_process_max_fds;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/prom/src/prom_process_limits_t.h
+++ b/prom/src/prom_process_limits_t.h
@@ -23,7 +23,6 @@
 extern prom_gauge_t *prom_process_open_fds;
 extern prom_gauge_t *prom_process_max_fds;
 extern prom_gauge_t *prom_process_virtual_memory_max_bytes;
-extern prom_gauge_t *prom_process_resident_memory_bytes;
 
 typedef struct prom_process_limits_row {
   const char *limit; /**< Pointer to a string */

--- a/prom/src/prom_process_stat.c
+++ b/prom/src/prom_process_stat.c
@@ -28,6 +28,7 @@
 
 prom_gauge_t *prom_process_cpu_seconds_total;
 prom_gauge_t *prom_process_virtual_memory_bytes;
+prom_gauge_t *prom_process_resident_memory_bytes;
 prom_gauge_t *prom_process_start_time_seconds;
 
 prom_process_stat_file_t *prom_process_stat_file_new(const char *path) {
@@ -183,6 +184,10 @@ int prom_process_stats_init(void) {
   // /proc/[pid]/stat Field 23
   prom_process_virtual_memory_bytes =
       prom_gauge_new("process_virtual_memory_bytes", "Virtual memory size in bytes.", 0, NULL);
+
+  // /proc/[pid]/stat Field 24
+  prom_process_resident_memory_bytes =
+      prom_gauge_new("process_resident_memory_bytes", "Resident memory size in bytes.", 0, NULL);
 
   prom_process_start_time_seconds =
       prom_gauge_new("process_start_time_seconds", "Start time of the process since unix epoch in seconds.", 0, NULL);

--- a/prom/src/prom_process_stat_t.h
+++ b/prom/src/prom_process_stat_t.h
@@ -22,6 +22,7 @@
 
 extern prom_gauge_t *prom_process_cpu_seconds_total;
 extern prom_gauge_t *prom_process_virtual_memory_bytes;
+extern prom_gauge_t *prom_process_resident_memory_bytes;
 extern prom_gauge_t *prom_process_start_time_seconds;
 
 /**

--- a/prom/test/prom_collector_test.c
+++ b/prom/test/prom_collector_test.c
@@ -30,7 +30,7 @@ void test_prom_process_collector(void) {
   prom_collector_t *collector =
       prom_collector_process_new("/code/prom/test/fixtures/limits", "/code/prom/test/fixtures/stat");
   prom_map_t *m = collector->collect_fn(collector);
-  TEST_ASSERT_EQUAL_INT(6, prom_map_size(m));
+  TEST_ASSERT_EQUAL_INT(7, prom_map_size(m));
   prom_collector_destroy(collector);
   collector = NULL;
 }


### PR DESCRIPTION
`process_resident_memory_bytes` is one of the metrics that are useful. Such metric are exposed by many collectors, Golang, nodejs etc.