### PR TITLE
Add method to unregister metrics

### DIFF
--- a/prom/include/prom_collector.h
+++ b/prom/include/prom_collector.h
@@ -88,6 +88,14 @@ int prom_collector_destroy_generic(void *gen);
 int prom_collector_add_metric(prom_collector_t *self, prom_metric_t *metric);
 
 /**
+ * @brief Remove a metric from a collector
+ * @param self The target prom_collector_t*
+ * @param metric the prom_metric_t* to remove from the prom_collector_t* passed as self.
+ * @return A non-zero integer value upon failure.
+ */
+int prom_collector_remove_metric(prom_collector_t *self, prom_metric_t *metric);
+
+/**
  * @brief The collect function is responsible for doing any work involving a set of metrics and then returning them
  *        for metric exposition.
  * @param self The target prom_collector_t*

--- a/prom/include/prom_collector_registry.h
+++ b/prom/include/prom_collector_registry.h
@@ -88,6 +88,15 @@ prom_metric_t *prom_collector_registry_must_register_metric(prom_metric_t *metri
 int prom_collector_registry_register_metric(prom_metric_t *metric);
 
 /**
+ * @brief Unregisters a metric with the default collector on PROM_DEFAULT_COLLECTOR_REGISTRY. Returns an non-zero integer
+ * value on failure.
+ *
+ * @param metric The metric to unregister on PROM_DEFAULT_COLLECTOR_REGISTRY*
+ * @return A non-zero integer value upon failure
+ */
+int prom_collector_registry_unregister_metric(prom_metric_t *metric);
+
+/**
  * @brief Register a collector with the given registry. Returns a non-zero integer value on failure.
  * @param self The target prom_collector_registry_t*
  * @param collector The prom_collector_t* to register onto the prom_collector_registry_t* as self

--- a/prom/src/prom_collector.c
+++ b/prom/src/prom_collector.c
@@ -116,6 +116,16 @@ int prom_collector_add_metric(prom_collector_t *self, prom_metric_t *metric) {
   return prom_map_set(self->metrics, metric->name, metric);
 }
 
+int prom_collector_remove_metric(prom_collector_t *self, prom_metric_t *metric) {
+  PROM_ASSERT(self != NULL);
+  if (self == NULL) return 1;
+  if (prom_map_get(self->metrics, metric->name) == NULL) {
+    PROM_LOG("metric not found in collector");
+    return 1;
+  }
+  return prom_map_delete(self->metrics, metric->name);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Process Collector
 

--- a/prom/src/prom_collector_registry.c
+++ b/prom/src/prom_collector_registry.c
@@ -143,6 +143,19 @@ int prom_collector_registry_register_metric(prom_metric_t *metric) {
   return prom_collector_add_metric(default_collector, metric);
 }
 
+int prom_collector_registry_unregister_metric(prom_metric_t *metric) {
+  PROM_ASSERT(metric != NULL);
+
+  prom_collector_t *default_collector =
+      (prom_collector_t *)prom_map_get(PROM_COLLECTOR_REGISTRY_DEFAULT->collectors, "default");
+
+  if (default_collector == NULL) {
+    return 1;
+  }
+
+  return prom_collector_remove_metric(default_collector, metric);
+}
+
 prom_metric_t *prom_collector_registry_must_register_metric(prom_metric_t *metric) {
   int err = prom_collector_registry_register_metric(metric);
   if (err != 0) {

--- a/prom/src/prom_map.c
+++ b/prom/src/prom_map.c
@@ -369,10 +369,10 @@ static int prom_map_delete_internal(const char *key, size_t *size, size_t *max_s
     prom_map_node_t *current_map_node = (prom_map_node_t *)current_node->item;
     prom_linked_list_compare_t result = prom_linked_list_compare(list, current_map_node, temp_map_node);
     if (result == PROM_EQUAL) {
-      r = prom_linked_list_remove(list, current_node);
+      r = prom_linked_list_remove(keys, (char *)current_map_node->key);
       if (r) return r;
 
-      r = prom_linked_list_remove(keys, (char *)current_map_node->key);
+      r = prom_linked_list_remove(list, current_node->item);
       if (r) return r;
 
       (*size)--;

--- a/prom/test/prom_collector_test.c
+++ b/prom/test/prom_collector_test.c
@@ -22,6 +22,9 @@ void test_prom_collector(void) {
   prom_collector_add_metric(collector, counter);
   prom_map_t *m = collector->collect_fn(collector);
   TEST_ASSERT_EQUAL_INT(1, prom_map_size(m));
+  prom_counter_inc(counter, NULL);
+  prom_collector_remove_metric(collector, counter);
+  TEST_ASSERT_EQUAL_INT(0, prom_map_size(m));
   prom_collector_destroy(collector);
   collector = NULL;
 }


### PR DESCRIPTION
Hello,

This PR adds `prom_collector_registry_unregister_metric()`. This gives the ability to remove metrics without having to restart the whole registry.

It also contains a fix for a crash in `prom_map_delete_internal` where the node is deleted before its key, resulting in using a deleted object when deleting the key later on.