### PR TITLE
Fix #64: failed build against newer libmicrohttpd versions

### DIFF
--- a/promhttp/src/promhttp.c
+++ b/promhttp/src/promhttp.c
@@ -29,8 +29,13 @@ void promhttp_set_active_collector_registry(prom_collector_registry_t *active_re
   }
 }
 
+#if MHD_VERSION >= 0x00097002
+enum MHD_Result promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
+                     const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls) {
+#else
 int promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
                      const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls) {
+#endif
   if (strcmp(method, "GET") != 0) {
     char *buf = "Invalid HTTP Method\n";
     struct MHD_Response *response = MHD_create_response_from_buffer(strlen(buf), (void *)buf, MHD_RESPMEM_PERSISTENT);


### PR DESCRIPTION
This MR fixes broken builds against newer `libmicrohttpd` versions while remaining compatible with the older ones. The change was introduced [back in April](https://git.gnunet.org/libmicrohttpd.git/tree/ChangeLog) last year by the upstream:

> Wed 08 Apr 2020 10:53:01 PM CEST
    Introduce `enum MHD_Result` for #MHD_YES/#MHD_NO to avoid using 'int' so much.
    Note that this change WILL cause compiler warnings until (most) MHD callbacks
    in application code change their return type from 'int' to 'enum MHD_Result'.
    That said, avoiding possible confusions of different enums is going to make
    the code more robust in the future. For conditional compilation, test
    for "MHD_VERSION >= 0x00097002". -CG

And here's the relevant commit: https://git.gnunet.org/libmicrohttpd.git/commit/?id=6347f514aa2388e774d5bf356df8046864e5f73c

Many thanks to @janv37 for hunting this one down 🙌🏻 