### PR TITLE
Add function to pass libmicrohttpd options when starting Prometheus listener

### DIFF
--- a/promhttp/include/promhttp.h
+++ b/promhttp/include/promhttp.h
@@ -46,3 +46,16 @@ void promhttp_set_active_collector_registry(prom_collector_registry_t *active_re
  */
 struct MHD_Daemon *promhttp_start_daemon(unsigned int flags, unsigned short port, MHD_AcceptPolicyCallback apc,
                                          void *apc_cls);
+
+/**
+ *  @brief Starts a daemon in the background and returns a pointer to an MHD_Daemon.
+ *
+ * This is the same as promhttp_start_daemon(), except it allows applications
+ * to pass options to MHD_start_daemon() directly.
+ *
+ * @return struct MHD_Daemon*
+ */
+struct MHD_Daemon *promhttp_start_daemon_with_options(unsigned int flags, unsigned short port,
+                                                      MHD_AcceptPolicyCallback apc,
+                                                      void *apc_cls, ...);
+

--- a/promhttp/src/promhttp.c
+++ b/promhttp/src/promhttp.c
@@ -15,6 +15,7 @@
  */
 
 #include <string.h>
+#include <stdarg.h>
 
 #include "microhttpd.h"
 #include "prom.h"
@@ -62,4 +63,23 @@ int promhttp_handler(void *cls, struct MHD_Connection *connection, const char *u
 struct MHD_Daemon *promhttp_start_daemon(unsigned int flags, unsigned short port, MHD_AcceptPolicyCallback apc,
                                          void *apc_cls) {
   return MHD_start_daemon(flags, port, apc, apc_cls, &promhttp_handler, NULL, MHD_OPTION_END);
+}
+
+static struct MHD_Daemon *promhttp_start_daemon_with_options_va(unsigned int flags, unsigned short port,
+                                                      MHD_AcceptPolicyCallback apc,
+                                                      void *apc_cls, va_list ap) {
+  return MHD_start_daemon_va(flags, port, apc, apc_cls, &promhttp_handler, NULL, ap);
+}
+
+struct MHD_Daemon *promhttp_start_daemon_with_options(unsigned int flags, unsigned short port,
+                                                      MHD_AcceptPolicyCallback apc,
+                                                      void *apc_cls, ...) {
+  va_list ap;
+  struct MHD_Daemon *ret;
+
+  va_start(ap, apc_cls);
+  ret = promhttp_start_daemon_with_options_va(flags, port, apc, apc_cls, ap);
+  va_end(ap);
+
+  return ret;
 }


### PR DESCRIPTION
This commit adds a new function, `promhttp_start_daemon_with_options()`, which exposes the variadic options interface of `MHD_start_daemon()` to applications using prometheus-client-c. This would allow applications to  e.g. bind to a specific IP address instead of the wildcard address, which is the libmicrohttpd default.