### PR TITLE
Fix MacOS build

### DIFF
--- a/prom/src/prom_metric_sample.c
+++ b/prom/src/prom_metric_sample.c
@@ -63,7 +63,7 @@ int prom_metric_sample_add(prom_metric_sample_t *self, double r_value) {
   if (r_value < 0) {
     return 1;
   }
-  _Atomic double old = atomic_load(&self->r_value);
+  double old = atomic_load(&self->r_value);
   for (;;) {
     _Atomic double new = ATOMIC_VAR_INIT(old + r_value);
     if (atomic_compare_exchange_weak(&self->r_value, &old, new)) {
@@ -78,7 +78,7 @@ int prom_metric_sample_sub(prom_metric_sample_t *self, double r_value) {
     PROM_LOG(PROM_METRIC_INCORRECT_TYPE);
     return 1;
   }
-  _Atomic double old = atomic_load(&self->r_value);
+  double old = atomic_load(&self->r_value);
   for (;;) {
     _Atomic double new = ATOMIC_VAR_INIT(old - r_value);
     if (atomic_compare_exchange_weak(&self->r_value, &old, new)) {

--- a/promhttp/src/promhttp.c
+++ b/promhttp/src/promhttp.c
@@ -29,7 +29,7 @@ void promhttp_set_active_collector_registry(prom_collector_registry_t *active_re
   }
 }
 
-int promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
+enum MHD_Result promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
                      const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls) {
   if (strcmp(method, "GET") != 0) {
     char *buf = "Invalid HTTP Method\n";


### PR DESCRIPTION
Fix build issues when compiling in MacOS.

1/ atomic_compare_exchange_weak expects a double* and not an Atomic double*.

2/ The microhttpd handler return value is MHD_Result instead of int.

I didn't test it in other systems, I hope some CI in the PRs test this still builds in different Linux flavours.