### PR TITLE
Metric "process_cpu_seconds_total" is now tracked as "double"

### DIFF
--- a/prom/src/prom_collector.c
+++ b/prom/src/prom_collector.c
@@ -222,7 +222,7 @@ prom_map_t *prom_collector_process_collect(prom_collector_t *self) {
   prom_process_stat_t *stat = prom_process_stat_new(stat_f);
 
   // Set the metrics related to the stat file
-  r = prom_gauge_set(prom_process_cpu_seconds_total, ((stat->utime + stat->stime) / sysconf(_SC_CLK_TCK)), NULL);
+  r = prom_gauge_set(prom_process_cpu_seconds_total, ((double)(stat->utime + stat->stime) / sysconf(_SC_CLK_TCK)), NULL);
   if (r) {
     prom_process_limits_file_destroy(limits_f);
     prom_map_destroy(limits_map);


### PR DESCRIPTION
This increases precision of the CPU usage, as previously only whole integers were counted.