### PR TITLE
Declare promhttp_handler with the correct return type

### DIFF
--- a/promhttp/include/promhttp.h
+++ b/promhttp/include/promhttp.h
@@ -36,6 +36,15 @@
  */
 void promhttp_set_active_collector_registry(prom_collector_registry_t *active_registry);
 
+#if MHD_VERSION >= 0x00097002
+#define PROM_MHD_RESULT enum MHD_Result
+#else
+#define PROM_MHD_RESULT int
+#endif
+
+PROM_MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
+                                 const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
+
 /**
  *  @brief Starts a daemon in the background and returns a pointer to an HMD_Daemon.
  *

--- a/promhttp/src/promhttp.c
+++ b/promhttp/src/promhttp.c
@@ -18,6 +18,7 @@
 
 #include "microhttpd.h"
 #include "prom.h"
+#include "promhttp.h"
 
 prom_collector_registry_t *PROM_ACTIVE_REGISTRY;
 
@@ -29,7 +30,7 @@ void promhttp_set_active_collector_registry(prom_collector_registry_t *active_re
   }
 }
 
-int promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
+PROM_MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
                      const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls) {
   if (strcmp(method, "GET") != 0) {
     char *buf = "Invalid HTTP Method\n";


### PR DESCRIPTION
The type of MHD_YES/NO changed in libmicrohttpd 0.9.70, so flexibility is needed for some time to avoid "incompatible pointer type" warning, which breaks the default build where warnings are treated as errors.

Furthermore the public declaration of promhttp_handler() is useful when the promhttpd_start_daemon() helper is not flexible enough and thus the library user has to invoke MHD_start_daemon() directly.

Fixes #72.