### PR TITLE
AIX 7.x build

### DIFF
--- a/autolib/build.sh
+++ b/autolib/build.sh
@@ -19,7 +19,7 @@ autolib_build() {
   pushd ${lib}/build > /dev/null || return $?
     autolib_output_banner "${lib}: CMake Build Stage"
     # YOU MUST set TEST to 1 in order to build the tests
-    TEST=$build_test cmake -v .. || {
+    TEST=$build_test cmake --log-level=VERBOSE .. || {
       autolib_output_error "${lib}: CMake Failure"
       return 1
     }

--- a/prom/CMakeLists.txt
+++ b/prom/CMakeLists.txt
@@ -120,7 +120,11 @@ target_sources(
     PRIVATE ${private_files}
 )
 
-target_link_libraries(prom PUBLIC Threads::Threads)
+if(UNIX AND NOT APPLE)
+  target_link_libraries(prom PUBLIC Threads::Threads -latomic)
+else()
+  target_link_libraries(prom PUBLIC Threads::Threads )
+endif()
 
 if ($ENV{TEST})
     include(test/CMakeLists.txt)

--- a/prom/src/prom_metric_sample.c
+++ b/prom/src/prom_metric_sample.c
@@ -63,7 +63,7 @@ int prom_metric_sample_add(prom_metric_sample_t *self, double r_value) {
   if (r_value < 0) {
     return 1;
   }
-  _Atomic double old = atomic_load(&self->r_value);
+  double old = atomic_load(&self->r_value);
   for (;;) {
     _Atomic double new = ATOMIC_VAR_INIT(old + r_value);
     if (atomic_compare_exchange_weak(&self->r_value, &old, new)) {
@@ -78,7 +78,7 @@ int prom_metric_sample_sub(prom_metric_sample_t *self, double r_value) {
     PROM_LOG(PROM_METRIC_INCORRECT_TYPE);
     return 1;
   }
-  _Atomic double old = atomic_load(&self->r_value);
+  double old = atomic_load(&self->r_value);
   for (;;) {
     _Atomic double new = ATOMIC_VAR_INIT(old - r_value);
     if (atomic_compare_exchange_weak(&self->r_value, &old, new)) {

--- a/promhttp/include/promhttp.h
+++ b/promhttp/include/promhttp.h
@@ -36,6 +36,16 @@
  */
 void promhttp_set_active_collector_registry(prom_collector_registry_t *active_registry);
 
+#if MHD_VERSION >= 0x00097002
+#define PROM_MHD_RESULT enum MHD_Result
+#else
+#define PROM_MHD_RESULT int
+#endif
+
+PROM_MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
+                                 const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
+
+
 /**
  *  @brief Starts a daemon in the background and returns a pointer to an HMD_Daemon.
  *

--- a/promhttp/src/promhttp.c
+++ b/promhttp/src/promhttp.c
@@ -18,6 +18,7 @@
 
 #include "microhttpd.h"
 #include "prom.h"
+#include "promhttp.h"
 
 prom_collector_registry_t *PROM_ACTIVE_REGISTRY;
 
@@ -29,7 +30,7 @@ void promhttp_set_active_collector_registry(prom_collector_registry_t *active_re
   }
 }
 
-int promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
+PROM_MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
                      const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls) {
   if (strcmp(method, "GET") != 0) {
     char *buf = "Invalid HTTP Method\n";


### PR DESCRIPTION
Fixed build issues when compiling on AIX 7.x systems.

1/ cmake -v flag migrated to --log-level=VERBOSE into autolib/build.sh

2/ link flag -latomic is needed on AIX. Tested ok on ubuntu and macOS 13
 
3/ included PL #79 the PROM_MHD_RESULT return for promhttp_handler()

4/ included PL #71 for macOS build.

Did not test the CI.