### PR TITLE
libprom: add pkg-config support

### DIFF
--- a/prom/CMakeLists.txt
+++ b/prom/CMakeLists.txt
@@ -136,6 +136,9 @@ set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../README.md)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A prometheus client library")
 set(CPACK_PACKAGE_HOMEPAGE_URL https://github.internal.digitalocean.com/timeseries/prometheus-client-c)
 
+set(target1 libprom)
+configure_file(libprom.pc.in ${CMAKE_INSTALL_LIBDIR}/pkgconfig/libprom.pc @ONLY)
+
 include(CPack)
 include(GNUInstallDirs)
 install(TARGETS prom ARCHIVE)

--- a/prom/libprom.pc.in
+++ b/prom/libprom.pc.in
@@ -1,0 +1,11 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: @CPACK_PACKAGE_DESCRIPTION_SUMMARY@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Libs: -L"${libdir}" -l@target1@
+Cflags: -I"${includedir}"

--- a/promhttp/CMakeLists.txt
+++ b/promhttp/CMakeLists.txt
@@ -76,6 +76,9 @@ set(CPACK_PACKAGE_HOMEPAGE_URL https://github.internal.digitalocean.com/timeseri
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libprom-dev (= ${Version})")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libmicrohttpd-dev")
 
+set(target1 libpromhttp)
+configure_file(libpromhttp.pc.in ${CMAKE_INSTALL_LIBDIR}/pkgconfig/libpromhttp.pc @ONLY)
+
 include(CPack)
 include(GNUInstallDirs)
 install(TARGETS promhttp ARCHIVE)

--- a/promhttp/libpromhttp.pc.in
+++ b/promhttp/libpromhttp.pc.in
@@ -1,0 +1,11 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: @CPACK_PACKAGE_DESCRIPTION_SUMMARY@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Libs: -L"${libdir}" -l@target1@
+Cflags: -I"${includedir}"


### PR DESCRIPTION
This will cause a libprom.pc file to be emitted during build, allowing downstream users to query linker/include flags via pkg-config.