### PR TITLE
CMake: add a top-level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.14.5)
+project(prometheus-client-c)
+
+add_subdirectory(prom)
+add_subdirectory(promhttp)


### PR DESCRIPTION
This is not the cleanest of solutions, but as long as the two buildsystems
are kept reasonably in sync, it will work.

This way it is more convenient to build both libraries at the same time
because CMake will take care of setting RPATH at the appropriate moment
to link one library against the other one (and clearing it afterwards
upon installation).