### PR TITLE
Build on Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,16 @@ on:
   - pull_request
 
 jobs:
+  ubuntu-22-04:
+    name: ubuntu-22-04
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: test
+        env:
+          DOCKER_IMAGE: ubuntu:22.04
+          CI: 1
+        run: make
   ubuntu-20-04:
     name: ubuntu-20-04
     runs-on: ubuntu-latest

--- a/auto
+++ b/auto
@@ -11,7 +11,7 @@ if [[ "$AUTO_DEBUG" == "1" ]]; then
 fi
 
 export PROJECT_ROOT=$(pushd $(dirname $0) > /dev/null; echo $PWD; popd > /dev/null)
-export DOCKER_IMAGE
+export DOCKER_IMAGE="${DOCKER_IMAGE:=ubuntu:22.04}"
 export CI=${CI:=0}
 export CC=/usr/bin/gcc
 

--- a/autolib/build.sh
+++ b/autolib/build.sh
@@ -19,7 +19,7 @@ autolib_build() {
   pushd ${lib}/build > /dev/null || return $?
     autolib_output_banner "${lib}: CMake Build Stage"
     # YOU MUST set TEST to 1 in order to build the tests
-    TEST=$build_test cmake -v .. || {
+    TEST=$build_test cmake .. || {
       autolib_output_error "${lib}: CMake Failure"
       return 1
     }

--- a/promhttp/include/promhttp.h
+++ b/promhttp/include/promhttp.h
@@ -36,6 +36,15 @@
  */
 void promhttp_set_active_collector_registry(prom_collector_registry_t *active_registry);
 
+#if MHD_VERSION >= 0x00097002
+#define PROM_MHD_RESULT enum MHD_Result
+#else
+#define PROM_MHD_RESULT int
+#endif
+
+PROM_MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
+                                 const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
+
 /**
  *  @brief Starts a daemon in the background and returns a pointer to an HMD_Daemon.
  *

--- a/promhttp/src/promhttp.c
+++ b/promhttp/src/promhttp.c
@@ -18,6 +18,7 @@
 
 #include "microhttpd.h"
 #include "prom.h"
+#include "promhttp.h"
 
 prom_collector_registry_t *PROM_ACTIVE_REGISTRY;
 
@@ -29,7 +30,7 @@ void promhttp_set_active_collector_registry(prom_collector_registry_t *active_re
   }
 }
 
-int promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
+PROM_MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
                      const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls) {
   if (strcmp(method, "GET") != 0) {
     char *buf = "Invalid HTTP Method\n";


### PR DESCRIPTION
* `autolib/docker.sh`: Add `autolib_new_ubuntu_22_04_template` function to generate `Dockerfile` for Ubuntu 22.04.
* `promhttp/include/promhttp.h` and `promhttp/src/promhttp.c`: Definitions changed in libmicrohttpd so change it to match.
* `autolib/build.sh`: Remove `-v` from the call to CMAKE so it is compatible with the version shipped in Ubuntu 22.04.
* `.github/workflows/ci.yaml`: Add workflow for Ubuntu 22.04.

---

Is this project/repository being actively maintained?

Any chance of making this available in Ubuntu 22.04 LTS and/or Ubuntu 24.04 LTS? 